### PR TITLE
Delete original subs

### DIFF
--- a/script.ps1
+++ b/script.ps1
@@ -40,6 +40,7 @@ for ($i = $startIndex; $i -le $endIndex; $i++) {
     # сам merge
     # из-за специфики запуска программ через *это*, настройки через параметры не удались. Поэтому всё делаем ручками.
     # если нужна оригинальная аудиодорожка, убираем "$removeOriginalSound"
+    # если нужны оригинальные субтитры, убираем "$removeOriginalSubs"
     # если не нужно внешнее аудио, то убираем "--language 0:rus $audioPathPrimary"
     # если нужна лишь одна аудиодорожка (только primary), то убираем "--language 0:eng $audioPathSecondary"
     # если не нужны внешние субтитры, то убираем "--language 0:rus --track-name 0:"Субтитры" $subtitlePath"

--- a/script.ps1
+++ b/script.ps1
@@ -9,6 +9,7 @@ param (
 )
 
 $removeOriginalSound = "-A"
+$removeOriginalSubs = "-S"
 
 for ($i = $startIndex; $i -le $endIndex; $i++) {
     # обработчик если номер серии всегда состоит из двух цифр
@@ -44,6 +45,6 @@ for ($i = $startIndex; $i -le $endIndex; $i++) {
     # если не нужны внешние субтитры, то убираем "--language 0:rus --track-name 0:"Субтитры" $subtitlePath"
     # если не нужны надписи, то убираем "--language 0:rus --track-name 0:"Надписи" $subtitleInscriptionsPath"
     # P.S. Изначально выбираемой дорожкой становится аудио, которое указано в параметрах раньше, а субтитры - последними
-    .\mkvmerge.exe -q -o $outPath $removeOriginalSound $videoPath --language 0:rus $audioPathPrimary --language 0:eng $audioPathSecondary --language 0:rus --track-name 0:"Субтитры" $subtitlePath --language 0:rus --track-name 0:"Надписи" $subtitleInscriptionsPath
+    .\mkvmerge.exe -q -o $outPath $removeOriginalSound $removeOriginalSubs $videoPath --language 0:rus $audioPathPrimary --language 0:eng $audioPathSecondary --language 0:rus --track-name 0:"Субтитры" $subtitlePath --language 0:rus --track-name 0:"Надписи" $subtitleInscriptionsPath
 }
 Write-Progress -Activity "Ready!" -Completed


### PR DESCRIPTION
Если в оригинальном файле есть субтитры, то новые субтитры не будут по умолчанию. Для избежания этой проблемы предлагаю добавить новый флаг `-S`, c которым не будет копирования субтитров из оригинального файла